### PR TITLE
修复anki_server运行时异常和PID信息不实引起的monit对anki_server监控失效的问题

### DIFF
--- a/anki_server/bin/anki_server_enable.service
+++ b/anki_server/bin/anki_server_enable.service
@@ -41,9 +41,8 @@ logger -st "($(basename $0))" $$ "*--------- ${SERVICE_NAME}_${SERVICE_FUNCTION}
 #
 ########## ENABLE ANKI-SERVER ##########
 #
+export LC_ALL="en_US.UTF-8"
 nohup ankiserverctl.py start ${PRIVATE_ETC}/production.ini &> /dev/null &
-PID=$(echo $!)
-echo ${PID} > /var/run/anki_server.pid
 #
 ########## END ##########
 #

--- a/anki_server/etc/monit.d/anki_server
+++ b/anki_server/etc/monit.d/anki_server
@@ -1,4 +1,4 @@
-check process ANKI_SERVER with pidfile '/var/run/anki_server.pid'
+check process ANKI_SERVER with matching '[python*serve] production.ini'
     start program = "/opt/script_bootloader/usr/anki_server/bin/anki_server_enable.service"
     stop program = "/opt/script_bootloader/usr/anki_server/bin/anki_server_disable.service"
     if does not exist then restart


### PR DESCRIPTION
TESTED: RT-AC68U 
固件： 384.10_2
原则上，针对类似启动python脚本服务的情况应该都适应，我只搭建了ANKI_SERVER，可以解决启动异常和运行监控问题。